### PR TITLE
Fix wttrin link

### DIFF
--- a/README.org
+++ b/README.org
@@ -1280,7 +1280,7 @@ For additional git-related emacs packages to use or to get inspiration from, tak
    - [[https://github.com/dakra/speed-type][speed-type]] - Practice speed/touch typing in Emacs.
    - [[https://gitlab.com/iankelling/spray][spray]] - A speed reading mode for Emacs.
    - [[https://github.com/kuanyui/fsc.el][fsc.el]] - Fuck the Speeching Censorship!
-   - [[https://github.com/bcbcarl/emacs-wttrin][wttrin]] - Emacs frontend for weather web service wttr.in.
+   - [[https://github.com/cjennings/emacs-wttrin][wttrin]] - Emacs frontend for weather web service wttr.in.
    - [[https://github.com/johanvts/emacs-fireplace][fireplace]] - A cozy fireplace for emacs.
    - [[https://github.com/Fuco1/clippy.el][clippy]] - Show tooltip with function documentation at point.
    - [[http://elpa.gnu.org/packages/landmark.html][Landmark]] - a neural network that trains a robot to find a tree.


### PR DESCRIPTION
## Summary
- update wttrin entry to point to new GitHub location

## Testing
- `make test` (fails: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_68b880e2dc908323a789cdc7e0321f50